### PR TITLE
fix(deps): bump gateway-api version to 1.32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.0</gravitee-gateway-api.version>
         <gravitee-resource-auth-provider.version>1.1.0</gravitee-resource-auth-provider.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7198

**Description**

The wrong version of `gravitee-gateway-api` had been set when merging #6772.

**Additional context**

Introduced with https://github.com/gravitee-io/issues/issues/6772
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.1-SNAPSHOT.3-15-compatibility`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-basic-authentication/1.3.1-SNAPSHOT.3-15-compatibility/gravitee-policy-basic-authentication-1.3.1-SNAPSHOT.3-15-compatibility.zip)
  <!-- Version placeholder end -->
