### PR TITLE
feat: update dependencies to be compatible with 3.15.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-auth-provider</artifactId>
             <version>${gravitee-resource-auth-provider.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Logging dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -30,20 +30,35 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19</version>
+        <version>20.2</version>
     </parent>
 
     <properties>
-        <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
+        <gravitee-bom.version>2.1</gravitee-bom.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-resource-auth-provider.version>1.1.0</gravitee-resource-auth-provider.version>
+        <gravitee-resource-auth-provider.version>1.3.0</gravitee-resource-auth-provider.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Gravitee dependencies -->
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Gravitee.io dependencies -->
@@ -78,7 +93,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -86,7 +100,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -94,14 +107,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7198

**Description**

 - update dependencies to be compatible with 3.15.x
 - set gravitee-resource-auth-provider as provided since it will be provided by APIM
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-SNAPSHOT.apim-3-15-compatibility`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-basic-authentication/1.4.0-SNAPSHOT.apim-3-15-compatibility/gravitee-policy-basic-authentication-1.4.0-SNAPSHOT.apim-3-15-compatibility.zip)
  <!-- Version placeholder end -->
