### PR TITLE
add the BASIC_AUTHENTICATION_UNAUTHORIZED response template

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,3 +40,20 @@ The policy configuration is as follows:
 |authenticationProviders||List of strings
 |realm||string
 |===
+
+=== Default response override
+
+You can use the response template feature to override the default responses provided by the policy. These templates must be defined at the API level (see the API Console *Response Templates*
+option in the API *Proxy* menu).
+
+=== Error keys
+
+The error keys sent by this policy are as follows:
+
+[cols="2*", options="header"]
+|===
+^|Key
+^|Parameters
+
+.^|BASIC_AUTHENTICATION_UNAUTHORIZED
+^.^|method, path


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7458

**Description**

add the **BASIC_AUTHENTICATION_UNAUTHORIZED** response template to override the default responses provided by the policy

**Additional context**
I've tested the changes with the graviteeio/apim-gateway:3.15.4 docker image using additionally the **inline auth provider (v1.3.0)** as an identity provider for the basic auth policy
