### PR TITLE
add a switcher for removing of the Authorization header

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,4 +39,5 @@ The policy configuration is as follows:
 
 |authenticationProviders||List of strings
 |realm||string
+|removeHeader|remove the *Authorization* header at the end of successful authentication|boolean
 |===

--- a/src/main/java/io/gravitee/policy/basicauth/BasicAuthenticationPolicy.java
+++ b/src/main/java/io/gravitee/policy/basicauth/BasicAuthenticationPolicy.java
@@ -99,6 +99,10 @@ public class BasicAuthenticationPolicy {
                     // No authentication provider matched, returning an authentication failure
                     sendAuthenticationFailure(response, policyChain);
                 } else {
+                    if (basicAuthenticationPolicyConfiguration.isRemoveHeader()) {
+                        request.headers().remove("Authorization");
+                    }
+
                     request.metrics().setUser(result);
                     policyChain.doNext(request, response);
                 }

--- a/src/main/java/io/gravitee/policy/basicauth/configuration/BasicAuthenticationPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/basicauth/configuration/BasicAuthenticationPolicyConfiguration.java
@@ -28,6 +28,8 @@ public class BasicAuthenticationPolicyConfiguration implements PolicyConfigurati
 
     private String realm;
 
+    private boolean removeHeader;
+
     public List<String> getAuthenticationProviders() {
         return authenticationProviders;
     }
@@ -42,5 +44,13 @@ public class BasicAuthenticationPolicyConfiguration implements PolicyConfigurati
 
     public void setRealm(String realm) {
         this.realm = realm;
+    }
+
+    public boolean isRemoveHeader() {
+        return removeHeader;
+    }
+
+    public void setRemoveHeader(boolean removeHeader) {
+        this.removeHeader = removeHeader;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -23,6 +23,12 @@
       "description": "The realm name showed to the client in case of error.",
       "type" : "string",
       "default": "gravitee.io"
+    },
+    "removeHeader": {
+      "title": "Remove Authorization header",
+      "description": "Remove the Authorization header after a processing",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": [


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7459

**Description**

Add a switcher for removing of the **Authorization** header at the end of successful authentication.

**Additional context**

I've tested the changes with the **graviteeio/apim-gateway:3.15.4** docker image using additionally the **inline auth provider (v1.3.0)** as an identity provider for the basic auth policy
