### PR TITLE
docs: add informations about connected user in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -30,6 +30,14 @@ To use the policy in an API, you need to:
 
 NOTE: LDAP, inline and http resources are not part of the default APIM configuration, so you must configure an LDAP, inline or http resource for APIM first, as described in the link:/apim/3.x/apim_devguide_plugins.html[Developer Guide^].
 
+=== Connected user
+
+After successful authentication, connected username is stored in context attributes, accessible with `context.attributes['user']` expression language.
+
+In order to display the connected username in API logging, you can enable the environment setting `Gateway > API logging > Display end user on API Logging`.
+
+This adds a `user` column in the logs table.
+
 == Configuration
 
 The policy configuration is as follows:


### PR DESCRIPTION
**Description**

docs: add informations about connected user in README
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-basic-authentication/1.4.1/gravitee-policy-basic-authentication-1.4.1.zip)
  <!-- Version placeholder end -->
