### PR TITLE
feat(basic-auth): Add support for custom user attribute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -57,3 +57,14 @@ The policy configuration is as follows:
 |authenticationProviders||List of strings
 |realm||string
 |===
+
+==== Gateway configuration (gravitee.yml)
+[source, yaml]
+----
+  policy:
+    basic-auth:
+      attributes:
+        user: gateway.username
+----
+
+The `policy.basic-auth.attributes.user` allow to configure the context attribute into which the user from the basic authentication will be injected.

--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,15 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.20.6</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-bom.version>4.0.3</gravitee-bom.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
+        <gravitee-common.version>2.1.0</gravitee-common.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider.version>1.3.0</gravitee-resource-auth-provider.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
@@ -89,6 +90,13 @@
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-auth-provider</artifactId>
             <version>${gravitee-resource-auth-provider.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1507

**Description**

This PR is providing:
* More logs in case of authentication failure
* Inject the username into a custom context attribute
* Inject the username to request metrics for further report
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.0-apim-1507-basic-auth-improvements-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-basic-authentication/1.5.0-apim-1507-basic-auth-improvements-SNAPSHOT/gravitee-policy-basic-authentication-1.5.0-apim-1507-basic-auth-improvements-SNAPSHOT.zip)
  <!-- Version placeholder end -->
