### PR TITLE
Apim 2140 basicauth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.1
+    gravitee: gravitee-io/gravitee@4.1.0
+
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +23,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +33,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,15 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-common.version>1.27.0</gravitee-common.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider.version>1.3.0</gravitee-resource-auth-provider.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
@@ -64,6 +65,13 @@
 
     <dependencies>
         <!-- Gravitee.io dependencies -->
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -5,3 +5,4 @@ description=${project.description}
 class=io.gravitee.policy.basicauth.BasicAuthenticationPolicy
 type=policy
 category=security
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,8 +1,9 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:basicauth:configuration:BasicAuthenticationPolicyConfiguration",
-  "properties" : {
-    "authenticationProviders" : {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "authenticationProviders": {
       "type" : "array",
       "title": "Authentication providers",
       "description": "Authentication provider resources used to authenticate users. By providing multiple providers, the gateway will try each of them until the user is authenticated.",
@@ -15,10 +16,16 @@
             "name": "fetch-resources",
             "regexTypes": "^auth-provider"
           }
+        },
+        "gioConfig": {
+          "uiType": "resource-type",
+          "uiTypeProps": {
+            "resourceType": "auth-provider"
+          }
         }
       }
     },
-    "realm" : {
+    "realm": {
       "title": "Realm name",
       "description": "The realm name showed to the client in case of error.",
       "type" : "string",


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**

* refactor the schema form to make it usable by studio v4
* define the proxy execution phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.0-apim-2140-basicauth-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-basic-authentication/1.5.0-apim-2140-basicauth-SNAPSHOT/gravitee-policy-basic-authentication-1.5.0-apim-2140-basicauth-SNAPSHOT.zip)
  <!-- Version placeholder end -->
