### PR TITLE
Enable policy on REQUEST phase for message APIs

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.basicauth.BasicAuthenticationPolicy
 type=policy
 category=security
 proxy=REQUEST
+message=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3594
gravitee-io/issues#9430

**Description**

Enable policy on REQUEST phase for message APIs
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.0-gaetanmaisse-patch-1-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-basic-authentication/1.6.0-gaetanmaisse-patch-1-SNAPSHOT/gravitee-policy-basic-authentication-1.6.0-gaetanmaisse-patch-1-SNAPSHOT.zip)
  <!-- Version placeholder end -->
